### PR TITLE
F/worker bootstrap error handling

### DIFF
--- a/src/SAREhub/DockerUtil/Worker/WorkerBootstrap.php
+++ b/src/SAREhub/DockerUtil/Worker/WorkerBootstrap.php
@@ -11,7 +11,7 @@ class WorkerBootstrap
     const ERROR_EXIT_CODE = 1;
 
     /**
-     * @var ContainerFactory
+     * @var ContainerFactory | string
      */
     private $containerFactory;
 
@@ -21,16 +21,21 @@ class WorkerBootstrap
     private $errorHandler;
 
     /**
-     * @param ContainerFactory $containerFactory
+     * @param ContainerFactory | string $containerFactory Object or class name
      * @param UnexpectedErrorHandler $errorHandler
      */
-    public function __construct(ContainerFactory $containerFactory, UnexpectedErrorHandler $errorHandler)
+    public function __construct($containerFactory, UnexpectedErrorHandler $errorHandler)
     {
         $this->containerFactory = $containerFactory;
         $this->errorHandler = $errorHandler;
     }
 
-    public static function create(ContainerFactory $containerFactory, UnexpectedErrorHandler $errorHandler): self
+    /**
+     * @param ContainerFactory | string $containerFactory Object or class name
+     * @param UnexpectedErrorHandler $errorHandler
+     * @return WorkerBootstrap
+     */
+    public static function create($containerFactory, UnexpectedErrorHandler $errorHandler): self
     {
         return new self($containerFactory, $errorHandler);
     }
@@ -42,7 +47,7 @@ class WorkerBootstrap
     public function run()
     {
         try {
-            $container = $this->containerFactory->create();
+            $container = $this->createContainer();
             $runner = $container->get(WorkerRunner::class);
             $runner->run();
         } catch (\Throwable $e) {
@@ -50,11 +55,16 @@ class WorkerBootstrap
         }
     }
 
+    private function createContainer(): ContainerInterface
+    {
+        $containerFactory = $this->containerFactory;
+        $containerFactory = (is_string($containerFactory)) ? new $containerFactory : $containerFactory;
+        return $containerFactory->create();
+    }
+
     private function handleUnexpectedError(\Throwable $e, ?ContainerInterface $container): void
     {
         $this->errorHandler->handle($e, $container);
         exit(self::ERROR_EXIT_CODE);
     }
-
-
 }

--- a/src/SAREhub/DockerUtil/Worker/WorkerBootstrap.php
+++ b/src/SAREhub/DockerUtil/Worker/WorkerBootstrap.php
@@ -21,6 +21,11 @@ class WorkerBootstrap
     private $errorHandler;
 
     /**
+     * @var callable
+     */
+    private $unexpectedErrorExitFunction;
+
+    /**
      * @param ContainerFactory | string $containerFactory Object or class name
      * @param UnexpectedErrorHandler $errorHandler
      */
@@ -28,6 +33,12 @@ class WorkerBootstrap
     {
         $this->containerFactory = $containerFactory;
         $this->errorHandler = $errorHandler;
+        $this->unexpectedErrorExitFunction = "exit";
+    }
+
+    public function setUnexpectedErrorExitFunction(callable $function)
+    {
+        $this->unexpectedErrorExitFunction = $function;
     }
 
     /**
@@ -65,6 +76,6 @@ class WorkerBootstrap
     private function handleUnexpectedError(\Throwable $e, ?ContainerInterface $container): void
     {
         $this->errorHandler->handle($e, $container);
-        exit(self::ERROR_EXIT_CODE);
+        ($this->unexpectedErrorExitFunction)(self::ERROR_EXIT_CODE);
     }
 }

--- a/tests/unit/SAREhub/DockerUtil/Worker/WorkerBootstrapTest.php
+++ b/tests/unit/SAREhub/DockerUtil/Worker/WorkerBootstrapTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SAREhub\DockerUtil\Worker;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use SAREhub\DockerUtil\Container\ContainerFactory;
+
+class WorkerBootstrapTest extends TestCase
+{
+
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var ContainerInterface | MockInterface
+     */
+    private $container;
+
+    /**
+     * @var ContainerFactory | MockInterface
+     */
+    private $containerFactory;
+
+    /**
+     * @var UnexpectedErrorHandler | MockInterface
+     */
+    private $unexpectedErrorHandler;
+
+    /**
+     * @var WorkerBootstrap
+     */
+    private $bootstrap;
+
+    protected function setUp()
+    {
+        $this->containerFactory = \Mockery::mock(ContainerFactory::class);
+        $this->container = \Mockery::mock(ContainerInterface::class);
+        $this->unexpectedErrorHandler = \Mockery::mock(UnexpectedErrorHandler::class);
+        $this->bootstrap = new WorkerBootstrap($this->containerFactory, $this->unexpectedErrorHandler);
+        $this->bootstrap->setUnexpectedErrorExitFunction(function () {
+        });
+    }
+
+    public function testRunThenWorkerRunnerRun()
+    {
+        $this->containerFactory->expects("create")->andReturn($this->container);
+        $runner = \Mockery::mock(WorkerRunner::class);
+        $this->container->expects("get")->with(WorkerRunner::class)->andReturn($runner);
+        $runner->expects("run");
+        $this->bootstrap->run();
+    }
+
+    public function testRunWhenCreateContainerError()
+    {
+        $exception = new \Exception();
+        $this->containerFactory->expects("create")->andThrow($exception);
+        $this->unexpectedErrorHandler->expects("handle")->with($exception, null);
+        $this->bootstrap->run();
+    }
+
+    public function testRunWhenWorkerRunnerRunError()
+    {
+        $this->containerFactory->expects("create")->andReturn($this->container);
+        $runner = \Mockery::mock(WorkerRunner::class);
+        $this->container->expects("get")->with(WorkerRunner::class)->andReturn($runner);
+
+        $exception = new \Exception();
+        $runner->expects("run")->andThrow($exception);
+        $this->unexpectedErrorHandler->expects("handle")->with($exception, $this->container);
+        $this->bootstrap->run();
+    }
+}


### PR DESCRIPTION
WorkerBoostrap::create() - now accepts class name as ContainerFactory its improving error handling when ContainerFactory::create() throws exception.